### PR TITLE
fix for Dockerfile and add Runme.io example runner

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,9 @@
 FROM node:10.19 AS node
 LABEL author="Harry Ho"
 WORKDIR /
-RUN npm install
 COPY . .
-RUN npm run build -- --prod
+RUN npm install
+RUN npm run build --prod
 
 
 ###### Run #####

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,6 @@ LABEL author="Harry Ho"
 WORKDIR /var/cache/nginx
 COPY --from=node /dist /usr/share/nginx/html
 COPY ./config/nginx.conf /etc/nginx/conf.d/default.conf
-EXPOSE 8080
 
 
 # ########################3# 

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,10 +13,10 @@ LABEL author="Harry Ho"
 WORKDIR /var/cache/nginx
 COPY --from=node /dist /usr/share/nginx/html
 COPY ./config/nginx.conf /etc/nginx/conf.d/default.conf
+EXPOSE 8080
 
 
 # ########################3# 
 # # docker build . -t  vc-prd:2.0
 # # docker run --publish 8080:80  --name vc2 vc-prd:2.0
-
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The goal of this project is to create a reusable starter project for real-world 
 
 
 ### Live Demo
-
+[![Runme](https://svc.runme.io/static/button.svg)](https://runme.io/run?app_id=a7bb2828-d650-4ca4-bfa6-a08547f5e8d6)
 [Demo App](https://vue-app-demo.harryho.org):  The demo is just a proof of concept. It doesn't have back-end API and all features of master branch.
 
 #### Screenshots ( The actual UI will be slightly different because I am lazy to keep up to date :p )

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ The goal of this project is to create a reusable starter project for real-world 
 
 ### Live Demo
 [![Runme](https://svc.runme.io/static/button.svg)](https://runme.io/run?app_id=a7bb2828-d650-4ca4-bfa6-a08547f5e8d6)
+
 [Demo App](https://vue-app-demo.harryho.org):  The demo is just a proof of concept. It doesn't have back-end API and all features of master branch.
 
 #### Screenshots ( The actual UI will be slightly different because I am lazy to keep up to date :p )


### PR DESCRIPTION
I've tried to use dockerfile and faced some issues with the building. It did not work if you do not have /node_modules before copy. With this change, all will work fine. You can check this on RunMe.io 

Additionally, this PR adds Runme button-label [![Runme](https://svc.runme.io/static/button.svg)](https://runme.io/run?app_id=0402fde3-cb34-4eb7-a4a7-db91ff830dcd) to run the project from the latest commit with one click.

**How it works:**
1. Runme clones the repository and builds a docker image for latest commit;
2. deploys docker image to k8s cluster;
3. creates domain with SSL certificate;
4. shows web application;
5. destroys app instance after 10 minutes.

You can find detailed information on how this works [here](https://runme.io/how-it-works). The small demo you can find [here](https://www.youtube.com/channel/UCEysV237wo321JatUTC6Rlg).

**Why do you need this?**
- Runme is a perfect solution to demonstrate the current state of code/repository, anybody can just click the button and see the state;
- Runme totally free, we love open source projects and want to support them;
- Runme has only one limit: you can run one commit no more than once every 5 minutes;